### PR TITLE
Omit Diagnostic.code if it is null

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { IConnection, TextDocument, TextDocuments, InitializeResult, createConnection } from 'vscode-languageserver';
+import { IConnection, TextDocument, TextDocuments, TextDocumentPositionParams, CompletionItem, InitializeResult, createConnection } from 'vscode-languageserver';
 import validateDocument from './validateDocument';
 
 export function createServer() {
@@ -18,6 +18,12 @@ export function createServer() {
 		documents.onDidChangeContent(change => validate(change.document));
 
 		connection.onDidChangeConfiguration(() => documents.all().forEach(validate));
+
+		connection.onCompletion(
+			(_textDocumentPosition: TextDocumentPositionParams): CompletionItem[] => {
+				return [];
+			}
+		);
 
 		return {
 			capabilities: {

--- a/src/validateDocument.ts
+++ b/src/validateDocument.ts
@@ -56,6 +56,8 @@ function makeDiagnostic(problem: Problem): Diagnostic {
         startChar = Math.max(0, problem.column - 1),
         endLine = problem.endLine != null ? Math.max(0, problem.endLine - 1) : startLine,
         endChar = problem.endColumn != null ? Math.max(0, problem.endColumn - 1) : startChar;
+
+    const code = (problem.ruleId != null) ? problem.ruleId : undefined
     
 	return {
 		message: message,
@@ -65,7 +67,7 @@ function makeDiagnostic(problem: Problem): Diagnostic {
 			start: { line: startLine, character: startChar },
 			end: { line: endLine, character: endChar }
 		},
-		code: problem.ruleId
+		code: code
 	};
 }
 


### PR DESCRIPTION
According to language protocol specs if 'code' exists it should be
either valid number or string:

    code?: number | string;
    /**
        * A human-readable string describing the source of this
        * diagnostic, e.g. 'typescript' or 'super lint'.
        */

In case code is null is should be removed.